### PR TITLE
Fixed bug with height of popup being slightly larger than googles max…

### DIFF
--- a/spawning-extension/src/views/components/Record/Record.module.scss
+++ b/spawning-extension/src/views/components/Record/Record.module.scss
@@ -1,6 +1,6 @@
 .recordCardWrapper {
   margin-top: 16px;
-  padding: 16px 24px;
+  padding: 12px 24px;
   border: 1px solid #eaecf0;
   border-radius: 8px;
 }
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .reportLink {


### PR DESCRIPTION
…imum popup dimension (600px). We were only a handful of pixels larger, so just reduced the padding a little in the table. It's barely noticeable imo.